### PR TITLE
Fix download

### DIFF
--- a/src/abstract/adapters.py
+++ b/src/abstract/adapters.py
@@ -11,7 +11,7 @@ class AWebClient(ABC):
 
 class AFileManager(ABC):
     @abstractmethod
-    async def save_file(self, files_dir, file: File, name: str):
+    async def save_file(self, files_dir, file: File):
         pass
 
     @abstractmethod

--- a/src/adapters.py
+++ b/src/adapters.py
@@ -20,22 +20,14 @@ class WebClient(abstract.AWebClient):
 
 
 class FileManager(abstract.AFileManager):
-    async def save_file(
-        self, files_dir: Path, file: File, name: str | None = None
-    ) -> str:
+    async def save_file(self, files_dir: Path, file: File) -> str:
         """
         Saving the file in the system.
         :param files_dir: dir of files
         :param file: bytes
-        :param name: file name. If None, then generate
         :return: file name
         """
-        if name and os.path.exists(files_dir / name):
-            # If a file with the given name already exists,
-            # it means it has already been saved.
-            return name
-
-        filename = name if name else self.generate_unique_filename()
+        filename = file.name if file.name else self.generate_unique_filename()
         while os.path.exists(files_dir / filename):
             # If a file with that name already exists, generate a new one
             filename = self.generate_unique_filename()

--- a/src/routes.py
+++ b/src/routes.py
@@ -30,8 +30,6 @@ class Handlers:
         async with timer:
             # downloading the content of the file
             file = await services.download_file(self.context, link)
-            # 'name' is passed in the case of file replication
-            file.name = file.name if not data.get("name") else data.get("name")
             # saving the file in the file system
             file_name = await services.save_file(self.context, file)
 

--- a/src/services.py
+++ b/src/services.py
@@ -12,12 +12,11 @@ async def download_file(context: Context, link: str) -> File:
     return await context.web.download_file(link)
 
 
-async def save_file(context: Context, file: File, name: str | None = None) -> str:
+async def save_file(context: Context, file: File) -> str:
     """
     Saving the file in the system and returning its name.
     :param context: Context instance
     :param file: bytes
-    :param name: file name. If None, then generate
     :return: file name
     """
-    return await context.files.save_file(context.FILES_DIR, file, name)
+    return await context.files.save_file(context.FILES_DIR, file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from src.main import init_app
 
 
 @pytest.fixture()
-def cli(loop, aiohttp_client) -> TestClient:
+def cli(event_loop, aiohttp_client) -> TestClient:
     """Getting the client for server testing."""
     app = init_app()
-    return loop.run_until_complete(aiohttp_client(app))
+    return event_loop.run_until_complete(aiohttp_client(app))

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_upload_file(cli, loop):
+async def test_upload_file(cli):
     file_link = "https://freetestdata.com/wp-content/uploads/2023/04/1.17-MB.bmp"
     response = await cli.post("/files/", data={"link": file_link})
     response_json = await response.json()


### PR DESCRIPTION
In the download_file_handler, there was a 'name' argument for file replication from other servers. This was incorrect because the handler was downloading the file from the provided link rather than accepting a file. Therefore, the argument was removed from it, as well as from the services where it was not needed.